### PR TITLE
Add typedb core artifact stub file

### DIFF
--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -1,0 +1,9 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def typedb_core_artifact():
+    """
+    Stub function to define TypeDB Core artifacts.
+    This function will be loaded in the WORKSPACE file to declare TypeDB dependencies.
+    """
+    # TODO: Implement TypeDB Core artifact definitions
+    pass


### PR DESCRIPTION
Add `dependencies/typedb/artifacts.bzl` with a `typedb_core_artifact()` stub to prepare for TypeDB dependency definitions.

---

[Open in Web](https://cursor.com/agents?id=bc-74c47a37-4f58-4f2e-a3f1-c423aad8387e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-74c47a37-4f58-4f2e-a3f1-c423aad8387e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)