### PR TITLE
Update docs with artifact loading function

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,5 @@
+workspace(name = "typedb_docs")
+
+# Load TypeDB dependencies
+load("//dependencies/typedb:artifacts.bzl", "typedb_dependencies")
+typedb_dependencies()

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -1,0 +1,35 @@
+"""
+TypeDB artifact loading functions.
+
+This module provides functions to load TypeDB artifacts from URLs.
+"""
+
+def typedb_artifact(name, url, sha256 = None, **kwargs):
+    """Load a TypeDB artifact from a URL.
+    
+    Args:
+        name: Name of the artifact target
+        url: URL to download the artifact from
+        sha256: Optional SHA256 checksum of the artifact
+        **kwargs: Additional arguments to pass to the http_file rule
+    """
+    native.http_file(
+        name = name,
+        url = url,
+        sha256 = sha256,
+        **kwargs
+    )
+
+def typedb_dependencies():
+    """Load all TypeDB dependencies.
+    
+    This is a macro that loads common TypeDB artifacts.
+    Add specific TypeDB artifacts here as needed.
+    """
+    # Example TypeDB artifact (this is a stub - replace with actual artifacts)
+    # typedb_artifact(
+    #     name = "typedb_server",
+    #     url = "https://github.com/vaticle/typedb/releases/download/VERSION/typedb-server-VERSION.zip",
+    #     sha256 = "actual_sha256_hash_here",
+    # )
+    pass


### PR DESCRIPTION
Add Bazel rules for loading TypeDB artifacts from URLs to enable declarative dependency management.

This implementation follows the existing Bazel dependency management patterns found in the repository, adapted for TypeDB artifacts loaded from URLs. It provides a `typedb_artifact` function and a `typedb_dependencies` macro for extensible and declarative management of TypeDB dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-5247ae55-88fc-4aef-9b57-d76cba528081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5247ae55-88fc-4aef-9b57-d76cba528081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>