### PR TITLE
Execute change to typedb docs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,7 @@
+workspace(name = "typedb_docs")
+
+# Load TypeDB artifacts
+load("//dependencies/typedb:artifacts.bzl", "load_typedb_artifacts")
+load_typedb_artifacts()
+
+# Additional workspace rules can be added here as needed

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -1,0 +1,58 @@
+"""
+TypeDB artifacts loading utilities for Bazel.
+
+This module provides functions to load TypeDB artifacts from remote URLs.
+"""
+
+def load_typedb_artifact(name, url, sha256 = None, strip_prefix = None, type = "zip"):
+    """
+    Load a TypeDB artifact from a remote URL.
+    
+    Args:
+        name: A unique name for this artifact.
+        url: The URL to download the artifact from.
+        sha256: Optional SHA256 checksum for verification.
+        strip_prefix: Optional prefix to strip from extracted files.
+        type: Type of archive (zip, tar.gz, etc.). Defaults to "zip".
+    """
+    if type == "zip":
+        native.http_archive(
+            name = name,
+            url = url,
+            sha256 = sha256,
+            strip_prefix = strip_prefix,
+        )
+    elif type == "tar.gz":
+        native.http_archive(
+            name = name,
+            url = url,
+            sha256 = sha256,
+            strip_prefix = strip_prefix,
+        )
+    elif type == "jar":
+        native.http_file(
+            name = name,
+            url = url,
+            sha256 = sha256,
+            downloaded_file_path = name + ".jar",
+        )
+    else:
+        fail("Unsupported artifact type: {}. Supported types: zip, tar.gz, jar".format(type))
+
+def load_typedb_artifacts():
+    """
+    Load all standard TypeDB artifacts.
+    
+    This function can be extended to include standard TypeDB dependencies
+    that are commonly used across projects.
+    """
+    
+    # Example TypeDB artifacts - these would be replaced with actual TypeDB URLs
+    load_typedb_artifact(
+        name = "typedb_client",
+        url = "https://repo1.maven.org/maven2/com/vaticle/typedb/typedb-client-java/2.14.1/typedb-client-java-2.14.1.jar",
+        sha256 = "example_sha256_hash_here",
+        type = "jar"
+    )
+    
+    # Add more standard TypeDB artifacts here as needed


### PR DESCRIPTION
Introduce Bazel `artifacts.bzl` and `WORKSPACE` files to enable loading TypeDB dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fec667e-660f-4174-ac75-5e6c53797ce6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fec667e-660f-4174-ac75-5e6c53797ce6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>