### PR TITLE
Create readme edit pr for typedb docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# TypeDB Documentation
+
+🚀 **[Get started quickly with TypeDB Cloud →](https://cloud.typedb.com)**
+
+Welcome to the TypeDB Documentation repository. This contains comprehensive documentation for TypeDB, covering everything from basic concepts to advanced usage patterns.
+
+## Documentation Structure
+
+- **[Get Started](docs/00-get-started/)** - Setup guides and quickstart tutorials
+- **[Cloud Deployment](docs/01-cloud-deployment/)** - TypeDB Cloud deployment and management
+- **[Knowledge Model](docs/02-knowledge-model/)** - Core concepts and data modeling
+- **[Building Schema](docs/03-building-schema/)** - Schema design and implementation
+- **[Querying Data](docs/04-querying-data/)** - TypeQL queries and data retrieval
+- **[Distributed Analytics](docs/05-distributed-analytics/)** - Analytics and distributed computing
+- **[Visualization Dashboard](docs/07-visualisation-dashboard/)** - Data visualization tools
+- **[Java Library](docs/08-java-library/)** - Java driver documentation
+- **[Language Drivers](docs/09-language-drivers/)** - Client drivers for various languages
+- **[API References](docs/10-api-references/)** - Complete API documentation
+- **[Resources](docs/11-resources/)** - Additional resources and examples
+- **[Examples](docs/12-examples/)** - Code examples and use cases
+
+## Quick Links
+
+- 🌐 **[TypeDB Cloud](https://cloud.typedb.com)** - Get started with TypeDB in the cloud
+- 📖 **[Main Documentation Portal](docs/0-index.md)** - Browse the full documentation
+- 💬 **[Community Forum](http://discuss.grakn.ai)** - Get help and discuss with the community
+- 📱 **[Slack Channel](https://grakn.ai/slack)** - Real-time community chat
+
+## Contributing
+
+We welcome contributions to improve the documentation. Please see our [contributing guidelines](contributors/index.html) for more information.


### PR DESCRIPTION
Create a new `README.md` file to add a prominent link to `cloud.typedb.com` and provide a central entry point for the documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-8aedd7b3-bb61-4417-8408-e8befd987afc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8aedd7b3-bb61-4417-8408-e8befd987afc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

